### PR TITLE
chore(bundle): reduce icon size bundle

### DIFF
--- a/lib/src/components/Navbar/Navbar.component.js
+++ b/lib/src/components/Navbar/Navbar.component.js
@@ -4,7 +4,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const react_1 = __importDefault(require("react"));
-const fa_1 = require("react-icons/fa");
+const FaBars_1 = require("@react-icons/all-files/fa/FaBars");
 const constants_1 = require("../../constants");
 const Avatar_1 = __importDefault(require("../Avatar"));
 const Navbar_component_styles_1 = require("./Navbar.component.styles");
@@ -15,7 +15,7 @@ const Navbar_component_styles_1 = require("./Navbar.component.styles");
  */
 const Navbar = ({ visible, onPressBurger }) => (react_1.default.createElement(Navbar_component_styles_1.Container, { visible: visible },
     react_1.default.createElement(Navbar_component_styles_1.IconBurgerContainer, { visible: visible, href: "#", onClick: onPressBurger },
-        react_1.default.createElement(fa_1.FaBars, null)),
+        react_1.default.createElement(FaBars_1.FaBars, null)),
     react_1.default.createElement(Navbar_component_styles_1.UserContainer, null,
         react_1.default.createElement(Navbar_component_styles_1.InlineText, null, "Hello,"),
         react_1.default.createElement(Navbar_component_styles_1.UserName, null, "Shipper User"),

--- a/lib/src/constants/index.js
+++ b/lib/src/constants/index.js
@@ -5,9 +5,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.NAVIGATION_MENU = exports.USER_AVATAR_URL = exports.PAGE = exports.USER_PER_PAGE = exports.TOTAL_USER = void 0;
 const react_1 = __importDefault(require("react"));
-const ti_1 = require("react-icons/ti");
-const ri_1 = require("react-icons/ri");
-const fa_1 = require("react-icons/fa");
+const TiHome_1 = require("@react-icons/all-files/ti/TiHome");
+const RiCalendar2Fill_1 = require("@react-icons/all-files/ri/RiCalendar2Fill");
+const FaUserCircle_1 = require("@react-icons/all-files/fa/FaUserCircle");
 exports.TOTAL_USER = 30;
 exports.USER_PER_PAGE = 5;
 exports.PAGE = exports.TOTAL_USER / exports.USER_PER_PAGE;
@@ -16,17 +16,17 @@ exports.NAVIGATION_MENU = [
     {
         title: 'Beranda',
         path: '#',
-        icon: react_1.default.createElement(ti_1.TiHome, null),
+        icon: react_1.default.createElement(TiHome_1.TiHome, null),
     },
     {
         title: 'Driver Management',
         path: '/driver-management',
-        icon: react_1.default.createElement(fa_1.FaUserCircle, null),
+        icon: react_1.default.createElement(FaUserCircle_1.FaUserCircle, null),
         isRoot: true,
     },
     {
         title: 'Pickup',
         path: '#',
-        icon: react_1.default.createElement(ri_1.RiCalendar2Fill, null)
+        icon: react_1.default.createElement(RiCalendar2Fill_1.RiCalendar2Fill, null)
     },
 ];

--- a/package.json
+++ b/package.json
@@ -18,17 +18,10 @@
     "next": "12.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-icons": "^4.4.0",
-    "styled-components": "^5.3.5"
+    "styled-components": "^5.3.5",
+    "@react-icons/all-files": "^4.1.0"
   },
   "devDependencies": {
-    "babel-plugin-styled-components": "^2.0.7",
-    "jest-environment-jsdom": "^29.0.1",
-    "next": "12.2.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-icons": "^4.4.0",
-    "styled-components": "^5.3.5",
     "@babel/preset-typescript": "^7.18.6",
     "@dmd/test": "github:metaufiq/dmd-test",
     "@dmd/types": "github:metaufiq/dmd-types",
@@ -39,11 +32,18 @@
     "@types/react": "18.0.17",
     "@types/react-dom": "18.0.6",
     "@types/styled-components": "^5.1.26",
+    "babel-plugin-styled-components": "^2.0.7",
     "eslint": "8.23.0",
     "eslint-config-next": "12.2.5",
     "eslint-plugin-jsdoc": "^39.3.6",
     "eslint-plugin-testing-library": "^5.6.0",
     "jest": "28.1.0",
+    "jest-environment-jsdom": "^29.0.1",
+    "next": "12.2.5",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "styled-components": "^5.3.5",
+    "@react-icons/all-files": "^4.1.0",
     "ts-jest": "^28.0.8",
     "typescript": "4.8.2"
   }

--- a/src/components/Navbar/Navbar.component.tsx
+++ b/src/components/Navbar/Navbar.component.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ReactElement } from "react";
-import {FaBars} from 'react-icons/fa'
+import {FaBars} from '@react-icons/all-files/fa/FaBars'
 
 import { Component } from "@dmd/types";
 import { USER_AVATAR_URL } from "../../constants";

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {TiHome} from 'react-icons/ti'
-import {RiCalendar2Fill} from 'react-icons/ri'
-import {FaUserCircle} from 'react-icons/fa'
+import {TiHome} from '@react-icons/all-files/ti/TiHome'
+import {RiCalendar2Fill} from '@react-icons/all-files/ri/RiCalendar2Fill'
+import {FaUserCircle} from '@react-icons/all-files/fa/FaUserCircle'
 
 export const TOTAL_USER = 30;
 export const USER_PER_PAGE = 5;

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,6 +841,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@react-icons/all-files@^4.1.0":
+  version "4.1.0"
+  resolved "https://nxrm.jenius.tech/repository/npm-group/@react-icons/all-files/-/all-files-4.1.0.tgz#477284873a0821928224b6fc84c62d2534d6650b"
+  integrity sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==
+
 "@rushstack/eslint-patch@^1.1.3":
   version "1.1.4"
   resolved "https://nxrm.jenius.tech/repository/npm-group/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz#0c8b74c50f29ee44f423f7416829c0bf8bb5eb27"
@@ -3750,11 +3755,6 @@ react-dom@18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
-
-react-icons@^4.4.0:
-  version "4.4.0"
-  resolved "https://nxrm.jenius.tech/repository/npm-group/react-icons/-/react-icons-4.4.0.tgz#a13a8a20c254854e1ec9aecef28a95cdf24ef703"
-  integrity sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
### WHAT PROBLEM DOES THIS PR SOLVE?
The bundle size of react-icons library is too big because the shaking tree modules and bundle from NextJS are unable to remove unused codes and icon data.

### How does this PR solve it?
used @react-icons/all-files as its alternative

Screenshots or GIFs:
**before**
<img width="1440" alt="Screen Shot 2022-08-30 at 11 46 47" src="https://user-images.githubusercontent.com/32932093/187345225-774d1122-87c9-4be3-843e-f36de2bcc89f.png">


**after**
<img width="1440" alt="Screen Shot 2022-08-30 at 11 46 15" src="https://user-images.githubusercontent.com/32932093/187345287-63e2801d-40fe-427e-abcd-917d009f9c3a.png">
